### PR TITLE
[FIX] Fixing issue when joining list with bytes instead of str

### DIFF
--- a/runbot_testing_recording/controllers/main.py
+++ b/runbot_testing_recording/controllers/main.py
@@ -441,7 +441,9 @@ def format_python_xml(model_name, method_name, args, kwargs, result):
         xml_id, vals, modelname, methodname = element
         data_to_xml.append(generate_xml_element(xml_id, vals, modelname, methodname))
 
-    return '\n'.join(data_to_xml)
+    # Depending on server configuration, we sometime receive bytes instead of str
+    # We have to make sure that join will be called with a list of str to avoid issues
+    return '\n'.join([str(datum) for datum in data_to_xml])
 
 def generate_formated_element(xml_id, values, model_name, method_name, data_to_format):
     global CREATED_IDS


### PR DESCRIPTION
When trying the runbot module on our environment, some errors occured when clicking on action buttons (create, save, custom buttons...).
After debugging, we happened to find the error cause and fixed it (join method must be used on list containing only str on certain versions of Python)
![runbot_bug](https://user-images.githubusercontent.com/49097377/68292619-8da45500-008c-11ea-9d05-cc009e6ec0e4.PNG)
